### PR TITLE
added serializer for user and added a error serializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "puma", ">= 5.0"
 gem "bcrypt", "~> 3.1.7"
 gem "jwt"
 gem "rspec-rails"
+gem "jsonapi-serializer"
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
     irb (1.14.3)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     jwt (2.10.1)
       base64
     kamal (2.4.0)
@@ -298,6 +300,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   debug
+  jsonapi-serializer
   jwt
   kamal
   pg (~> 1.1)

--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::Admin::UsersController < ApplicationController
   def index
     artists = User.artist
     buyers = User.buyer
-    render json: { artists: artists, buyers: buyers }, status: :ok
+    render json: { artists: UserSerializer.new(artists), buyers: UserSerializer.new(buyers) }, status: :ok
   end
 
   private

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::AuthController < ApplicationController
     user = User.find_by(email: params[:email])
     if user&.authenticate(params[:password])
       token = encode_token({ user_id: user.id })
-      render json: { token: token, user: user }, status: :ok
+      render json: { token: token, user: UserSerializer.new(user) }, status: :ok
     else
       render json: { error: "Invalid credentials" }, status: :unauthorized
     end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -2,9 +2,9 @@ class Api::V1::UsersController < ApplicationController
   def create
     user = User.new(user_params)
     if user.save 
-      render json: { message: "User created!!", user: user}, status: :created
+      render json: { message: "User created!!", user: UserSerializer.new(user)}, status: :created
     else
-      render json: { errors: user.errors.full_messages}, status: :unprocessable_entity
+      render json: ErrorSerializer.format_error(ErrorMessage.new(user.errors.full_messages, 422)), status: :unprocessable_entity
     end
   end
 

--- a/app/poro/error_message.rb
+++ b/app/poro/error_message.rb
@@ -1,0 +1,8 @@
+class ErrorMessage
+  attr_reader :message, :status_code
+  
+  def initialize(message, status_code)
+    @message = message
+    @status_code = status_code
+  end
+end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,0 +1,9 @@
+class ErrorSerializer
+
+  def self.format_error(error_message)
+    {
+      message: error_message.message,
+      status: error_message.status_code
+    }
+  end
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,4 @@
+class UserSerializer
+  include JSONAPI::Serializer
+  attributes :name, :email, :password, :role
+end

--- a/spec/requests/api/v1/admin/users_spec.rb
+++ b/spec/requests/api/v1/admin/users_spec.rb
@@ -24,20 +24,17 @@ RSpec.describe "Api::V1::Admin::Users", type: :request do
 
       user_role_info = JSON.parse(response.body, symbolize_names: true)
       
-      expect(user_role_info[:artists][0][:id]).to be_an(Integer)
-      expect(user_role_info[:artists][0][:name]).to be_a(String)
-      expect(user_role_info[:artists][0][:email]).to be_a(String)
-      expect(user_role_info[:artists][0][:password_digest]).to be_a(String)
-      expect(user_role_info[:artists][0][:role]).to be_a(String)
-      expect(user_role_info[:artists][0][:created_at]).to be_a(String)
-      expect(user_role_info[:artists][0][:updated_at]).to be_a(String)
-      expect(user_role_info[:buyers][0][:id]).to be_an(Integer)
-      expect(user_role_info[:buyers][0][:name]).to be_a(String)
-      expect(user_role_info[:buyers][0][:email]).to be_a(String)
-      expect(user_role_info[:buyers][0][:password_digest]).to be_a(String)
-      expect(user_role_info[:buyers][0][:role]).to be_a(String)
-      expect(user_role_info[:buyers][0][:created_at]).to be_a(String)
-      expect(user_role_info[:buyers][0][:updated_at]).to be_a(String)
+      expect(user_role_info[:artists][:data][0][:id]).to be_a(String)
+      expect(user_role_info[:artists][:data][0][:attributes][:name]).to be_a(String)
+      expect(user_role_info[:artists][:data][0][:attributes][:email]).to be_a(String)
+      expect(user_role_info[:artists][:data][0][:attributes][:password]).to be_nil 
+      expect(user_role_info[:artists][:data][0][:attributes][:role]).to be_a(String)
+
+      expect(user_role_info[:buyers][:data][0][:id]).to be_a(String)
+      expect(user_role_info[:buyers][:data][0][:attributes][:name]).to be_a(String)
+      expect(user_role_info[:buyers][:data][0][:attributes][:email]).to be_a(String)
+      expect(user_role_info[:buyers][:data][0][:attributes][:password]).to be_nil
+      expect(user_role_info[:buyers][:data][0][:attributes][:role]).to be_a(String)
     end
   end
 end

--- a/spec/requests/api/v1/auth_spec.rb
+++ b/spec/requests/api/v1/auth_spec.rb
@@ -9,16 +9,15 @@ RSpec.describe "Api::V1::Auths", type: :request do
       expect(response).to be_successful
 
       jwt = JSON.parse(response.body, symbolize_names: true)
-      # require 'pry'; binding.pry
+      
       expect(jwt[:token]).to be_a(String)
-      expect(jwt[:user]).to be_an(Hash)
-      expect(jwt[:user][:id]).to be_a(Integer)
-      expect(jwt[:user][:name]).to be_a(String)
-      expect(jwt[:user][:email]).to be_a(String)
-      expect(jwt[:user][:password_digest]).to be_a(String)
-      expect(jwt[:user][:role]).to be_a(String)
-      expect(jwt[:user][:created_at]).to be_a(String)
-      expect(jwt[:user][:updated_at]).to be_a(String)
+      expect(jwt[:user][:data]).to be_an(Hash)
+      expect(jwt[:user][:data][:id]).to be_a(String)
+      expect(jwt[:user][:data][:type]).to be_a(String)
+      expect(jwt[:user][:data][:attributes][:name]).to be_a(String)
+      expect(jwt[:user][:data][:attributes][:email]).to be_a(String)
+      expect(jwt[:user][:data][:attributes][:password]).to be_nil
+      expect(jwt[:user][:data][:attributes][:role]).to be_a(String)
     end
   end
 end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Api::V1::Users", type: :request do
       user_params = {
         user: {
           name: "Melchor",
-          email: "melchor@example.com",
+          email: "mel@example.com",
           password: "paswword",
           role: :artist
         }
@@ -19,15 +19,31 @@ RSpec.describe "Api::V1::Users", type: :request do
       user = JSON.parse(response.body, symbolize_names: true)
       
       expect(user[:message]).to eq("User created!!")
-      expect(user[:user]).to be_a(Hash)
-      expect(user[:user][:id]).to be_an(Integer)
-      expect(user[:user][:name]).to be_a(String)
-      expect(user[:user][:email]).to be_a(String)
-      expect(user[:user][:password_digest]).to be_a(String)
-      expect(user[:user][:role]).to be_a(String)
-      expect(user[:user][:created_at]).to be_a(String)
-      expect(user[:user][:updated_at]).to be_a(String)
+      expect(user[:user][:data]).to be_a(Hash)
+      expect(user[:user][:data][:id]).to be_a(String)
+      expect(user[:user][:data][:type]).to be_a(String)
+      expect(user[:user][:data][:attributes][:name]).to be_a(String)
+      expect(user[:user][:data][:attributes][:email]).to be_a(String)
+      expect(user[:user][:data][:attributes][:password]).to be_a(String)
+      expect(user[:user][:data][:attributes][:role]).to be_a(String)
+    end
+
+    it "returns an error for missing params" do
+      user_params = {
+        user: {
+          name: "",
+          email: "mel@example.com",
+          password: "paswword",
+          role: :artist
+        }
+      }
+
+      post "/api/v1/users", params: user_params
+      
+      error_message = JSON.parse(response.body, symbolize_names: true)
+
+      expect(error_message[:message]).to include("Name can't be blank")
+      expect(error_message[:status]).to eq(422)
     end
   end
-
 end


### PR DESCRIPTION
Added User and Error Serializers for Improved API Responses

This PR introduces serializers to streamline and standardize the structure of API responses:

- UserSerializer: Formats user data for consistent and concise JSON responses across endpoints, replacing raw user object returns.

- ErrorSerializer: Simplifies error handling by encapsulating error messages and status codes into a unified format using the newly added ErrorMessage PORO.

- Updated controllers to use the new serializers, ensuring clean and predictable API responses.
- Added and updated RSpec tests to validate the changes, ensuring accurate serialization for both success and error cases.

- Included jsonapi-serializer gem for efficient serialization.