### PR TITLE
added an index action for orders and updated the artworks index action

### DIFF
--- a/app/controllers/api/v1/artworks_controller.rb
+++ b/app/controllers/api/v1/artworks_controller.rb
@@ -3,7 +3,11 @@ class Api::V1::ArtworksController < ApplicationController
   before_action :authorize_artist
   
   def index
-    artworks = @current_user.artworks 
+    artworks = if @current_user.artist?
+                 @current_user.artworks
+               else
+                 Artwork.all
+               end
     render json: artworks, status: :ok
   end
 

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -1,6 +1,11 @@
 class Api::V1::OrdersController < ApplicationController
   before_action :authenticate_user
   before_action :authorize_buyer
+
+  def index
+    orders = @current_user.orders
+    render json: orders.as_json(include: :order_items), status: :ok
+  end
   
   def create
     order = @current_user.orders.new(order_params)

--- a/spec/requests/api/v1/orders_spec.rb
+++ b/spec/requests/api/v1/orders_spec.rb
@@ -44,4 +44,42 @@ RSpec.describe "Api::V1::Orders", type: :request do
       expect(order[:order_items][0][:updated_at]).to be_a(String)
     end
   end
+
+  describe "GET/index" do
+    it "should retreive a list of all the orders of a buyer" do 
+      user = User.create!(name: "Mel", email: "mel@example.com", password: "melchor08", role: :buyer)
+
+      post "/api/v1/auth", params: { email: user.email, password: user.password }
+      
+      expect(response).to be_successful
+
+      token = JSON.parse(response.body)["token"]
+      
+      expect(token).to_not be_nil
+      expect(token).to be_a(String)
+      expect(token.split('.').length).to eq(3)
+
+      artwork = Artwork.create!(title: "Painting", description: "Beautiful artwork", price: 600000, user_id: user.id)
+      Order.create!(user_id: user.id, total_price: 3000000, order_items_attributes: [{ artwork_id: artwork.id, quantity: 5, price: 600000 }])
+
+      get "/api/v1/users/#{user.id}/orders", headers: { "Authorization" => "Bearer #{token}" }, as: :json
+      
+      expect(response).to be_successful
+
+      orders = JSON.parse(response.body, symbolize_names: true)
+      
+
+      expect(orders[0][:id]).to be_an(Integer) 
+      expect(orders[0][:user_id]).to be_an(Integer)
+      expect(orders[0][:total_price]).to be_a(String)
+      expect(orders[0][:order_items]).to be_an(Array)
+      expect(orders[0][:order_items].first).to include(
+        id: be_an(Integer),
+        order_id: be_an(Integer),
+        artwork_id: be_an(Integer),
+        quantity: be_an(Integer),
+        price: be_a(String)
+      )
+    end
+  end
 end


### PR DESCRIPTION
This PR introduces the following updates:

Artworks Controller:

- Enhanced the index action to return artworks based on the user's role:
- Artists see only their artworks.
- Buyers see all artworks.

Orders Controller:

- Added a new index action to retrieve a list of all orders for the authenticated user.
- Orders are returned with associated order_items for comprehensive data.

Orders Spec:

- Added a new test for the GET /index endpoint in the OrdersController to ensure it retrieves orders with the correct structure, including associated order_items.

These changes improve functionality and ensure role-specific data access while maintaining consistency in API responses.